### PR TITLE
docs: add project PRD and roadmap

### DIFF
--- a/.github/profile/README.md
+++ b/.github/profile/README.md
@@ -1,0 +1,8 @@
+# Streamertools
+
+Open-source tools for streamers. The main project, [MeTuber](../../MeTuber), provides real-time filters and overlays for webcam feeds in OBS.
+
+- [Product Requirements](../../docs/PRD.md)
+- [Roadmap](../../docs/ROADMAP.md)
+
+Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Streamertools
 
-various free opensource resources for streamers/streaming
+Streamertools is a collection of free, open-source resources for streamers. The primary project is [MeTuber](./MeTuber), a Python library that applies real-time filters and overlays to webcam feeds for use with OBS.
+
+## Documentation
+- [Product Requirements Document](docs/PRD.md)
+- [Roadmap](docs/ROADMAP.md)
+
+## Development
+See [MeTuber/README.md](MeTuber/README.md) for installation, usage, and contribution details.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,31 @@
+# Streamertools Product Requirements Document
+
+## Overview
+Streamertools provides a suite of free, open-source tools for livestreamers. The initial focus is the **MeTuber** library, which applies real-time image filters and overlays to webcam feeds for use with OBS.
+
+## Problem Statement
+Streamers lack a lightweight, customizable library for applying artistic effects to live video without relying on proprietary solutions.
+
+## Goals
+- Offer a modular Python library for filters and overlays.
+- Integrate easily with OBS and typical streaming setups.
+- Maintain high test coverage and developer-friendly documentation.
+
+## Target Audience
+- Streamers who want creative control over their webcam feed.
+- Developers interested in extending and customizing video effects.
+
+## Key Features
+- Image filters such as vibrant color, black and white, and sepia.
+- Overlay effects including halftones, glitches, and light leaks.
+- Bitwise operations for advanced visual effects.
+- Modular style system for adding new effects quickly.
+
+## Non-Goals
+- Full video editing or streaming platform management.
+- Proprietary or paid effects.
+
+## Success Metrics
+- Number of built-in styles and community contributions.
+- Test coverage above 80%.
+- Adoption measured by PyPI downloads and GitHub stars.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,20 @@
+# Streamertools Roadmap
+
+## 2024 Q4 (Current)
+- Document project goals and status.
+- Improve repository README and GitHub profile.
+
+## 2025 Q1
+- Package MeTuber for PyPI distribution.
+- Add a simple GUI for selecting and stacking filters.
+- Expand built-in style library (blur, chroma key, etc.).
+- Increase automated test coverage.
+
+## 2025 Q2
+- Provide an OBS plug-in for direct integration.
+- Create cross-platform executables for Windows, macOS, and Linux.
+- Publish a documentation website with tutorials.
+
+## Future
+- Support filters for additional platforms such as YouTube Live and Zoom.
+- Build a community-driven marketplace for sharing styles.


### PR DESCRIPTION
## Summary
- add PRD outlining MeTuber's goals, target users and features
- introduce a roadmap for upcoming releases
- expand project README and add GitHub profile overview

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cv2'; 43 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a85c8e9f34832985c9a2bf2f50810b