### PR TITLE
Enable toggling of action buttons

### DIFF
--- a/MeTuber/src/gui/components/action_buttons.py
+++ b/MeTuber/src/gui/components/action_buttons.py
@@ -95,14 +95,18 @@ class ActionButtons(QWidget):
             
     def set_enabled(self, enabled: bool) -> None:
         """Enable or disable all buttons.
-        
+
         Args:
             enabled: Whether to enable or disable the buttons
         """
         try:
             self.start_button.setEnabled(enabled)
-            self.stop_button.setEnabled(False)
-            self.snapshot_button.setEnabled(False)
-            self.logger.debug(f"All buttons {'enabled' if enabled else 'disabled'}")
+            self.stop_button.setEnabled(enabled)
+            self.snapshot_button.setEnabled(enabled)
+            self.logger.debug(
+                f"All buttons {'enabled' if enabled else 'disabled'}"
+            )
         except Exception as e:
-            self.logger.error(f"Error setting button enabled states: {str(e)}") 
+            self.logger.error(
+                f"Error setting button enabled states: {str(e)}"
+            )


### PR DESCRIPTION
## Summary
- Allow `ActionButtons.set_enabled` to toggle all buttons instead of leaving Stop and Snapshot disabled
- Keep `_reset_button_states` for restoring the initial Start-enabled configuration

## Testing
- `pytest` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a286e7f03c8329aa27f968f8bb739b