### PR TITLE
Reset buttons on webcam errors

### DIFF
--- a/MeTuber/src/gui/v2_main_window.py
+++ b/MeTuber/src/gui/v2_main_window.py
@@ -525,7 +525,9 @@ class V2MainWindow(QMainWindow):
             self.preview_area.show_error(message)
             self.status_label.setText(f"Error: {message}")
             self.logger.error(f"Webcam error: {message}")
-            
+            self.action_buttons._reset_button_states()
+            self.preview_area.set_playing_state(False)
+
         except Exception as e:
             self.logger.error(f"Error handling webcam error: {e}")
     


### PR DESCRIPTION
## Summary
- Reset action buttons and stop preview when webcam service reports an error.

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q` *(fails: segmentation fault after running tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a286e67c748329a48614012d462184