### PR TITLE
Handle start button states after webcam service start

### DIFF
--- a/MeTuber/src/gui/components/action_buttons.py
+++ b/MeTuber/src/gui/components/action_buttons.py
@@ -54,9 +54,6 @@ class ActionButtons(QWidget):
     def _on_start_clicked(self) -> None:
         """Handle start button click event."""
         try:
-            self.start_button.setEnabled(False)
-            self.stop_button.setEnabled(True)
-            self.snapshot_button.setEnabled(True)
             self.start_camera.emit()
             self.logger.debug("Start camera signal emitted")
         except Exception as e:

--- a/MeTuber/src/gui/v2_main_window.py
+++ b/MeTuber/src/gui/v2_main_window.py
@@ -423,10 +423,12 @@ class V2MainWindow(QMainWindow):
                 self.preview_area.set_playing_state(True)
                 self.action_buttons.start_button.setEnabled(False)
                 self.action_buttons.stop_button.setEnabled(True)
+                self.action_buttons.snapshot_button.setEnabled(True)
                 self.status_label.setText("Camera started")
                 self.accessibility_manager.announce_status("Camera started")
             else:
                 QMessageBox.critical(self, "Error", "Failed to start camera")
+                self.action_buttons._reset_button_states()
             
         except Exception as e:
             self.logger.error(f"Error starting camera: {e}")


### PR DESCRIPTION
## Summary
- Emit `start_camera` without toggling button states in ActionButtons
- Move button state updates to V2 main window based on webcam start success

## Testing
- `pytest -q` *(fails: Fatal Python error: Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a286e5c81883299f85573a3cd4002e