### PR TITLE
Ensure action buttons reset on camera start failures

### DIFF
--- a/MeTuber/src/gui/components/action_buttons.py
+++ b/MeTuber/src/gui/components/action_buttons.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Callable
+from typing import Optional
 from PyQt5.QtWidgets import QWidget, QPushButton, QHBoxLayout
 from PyQt5.QtCore import pyqtSignal
 
@@ -61,7 +61,7 @@ class ActionButtons(QWidget):
             self.logger.debug("Start camera signal emitted")
         except Exception as e:
             self.logger.error(f"Error handling start button click: {str(e)}")
-            self._reset_button_states()
+            self.reset()
             
     def _on_stop_clicked(self) -> None:
         """Handle stop button click event."""
@@ -73,7 +73,7 @@ class ActionButtons(QWidget):
             self.logger.debug("Stop camera signal emitted")
         except Exception as e:
             self.logger.error(f"Error handling stop button click: {str(e)}")
-            self._reset_button_states()
+            self.reset()
             
     def _on_snapshot_clicked(self) -> None:
         """Handle snapshot button click event."""
@@ -83,7 +83,7 @@ class ActionButtons(QWidget):
         except Exception as e:
             self.logger.error(f"Error handling snapshot button click: {str(e)}")
             
-    def _reset_button_states(self) -> None:
+    def reset(self) -> None:
         """Reset all buttons to their default states."""
         try:
             self.start_button.setEnabled(True)
@@ -105,4 +105,4 @@ class ActionButtons(QWidget):
             self.snapshot_button.setEnabled(False)
             self.logger.debug(f"All buttons {'enabled' if enabled else 'disabled'}")
         except Exception as e:
-            self.logger.error(f"Error setting button enabled states: {str(e)}") 
+            self.logger.error(f"Error setting button enabled states: {str(e)}")

--- a/MeTuber/src/gui/v2_main_window.py
+++ b/MeTuber/src/gui/v2_main_window.py
@@ -398,6 +398,7 @@ class V2MainWindow(QMainWindow):
             device_name = self.device_combo.currentText()
             if not device_name:
                 QMessageBox.warning(self, "Warning", "Please select a camera device")
+                self.action_buttons.reset()
                 return
             
             # Convert device name to device ID
@@ -413,6 +414,7 @@ class V2MainWindow(QMainWindow):
             
             if not device_id:
                 QMessageBox.critical(self, "Error", f"Device ID not found for {device_name}")
+                self.action_buttons.reset()
                 return
             
             # Get current style and parameters
@@ -427,10 +429,12 @@ class V2MainWindow(QMainWindow):
                 self.accessibility_manager.announce_status("Camera started")
             else:
                 QMessageBox.critical(self, "Error", "Failed to start camera")
+                self.action_buttons.reset()
             
         except Exception as e:
             self.logger.error(f"Error starting camera: {e}")
             QMessageBox.critical(self, "Error", f"Failed to start camera: {str(e)}")
+            self.action_buttons.reset()
     
     def _stop_camera(self) -> None:
         """Stop the webcam service."""


### PR DESCRIPTION
## Summary
- add public `reset` to `ActionButtons` to restore button states
- call `reset` in `_start_camera` when initialization fails or errors

## Testing
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
from PyQt5.QtWidgets import QApplication, QMessageBox
from src.gui.v2_main_window import V2MainWindow
from src.core.device_manager import DeviceManagerFactory

QMessageBox.warning = lambda *args, **kwargs: QMessageBox.Ok
QMessageBox.critical = lambda *args, **kwargs: QMessageBox.Ok

class DummyDeviceManager:
    def get_devices(self):
        return []

DeviceManagerFactory.create = staticmethod(lambda: DummyDeviceManager())

app = QApplication([])
window = V2MainWindow()
window.device_combo.addItem('Invalid Device')
window.device_combo.setCurrentText('Invalid Device')
# device_manager already returns []
window.action_buttons._on_start_clicked()
print('Start enabled:', window.action_buttons.start_button.isEnabled())
print('Stop enabled:', window.action_buttons.stop_button.isEnabled())
print('Snapshot enabled:', window.action_buttons.snapshot_button.isEnabled())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a286de48f883299ed5586e4090db56