### PR TITLE
Stop camera on webcam errors

### DIFF
--- a/MeTuber/src/gui/v2_main_window.py
+++ b/MeTuber/src/gui/v2_main_window.py
@@ -522,10 +522,14 @@ class V2MainWindow(QMainWindow):
     def _on_webcam_error(self, message: str) -> None:
         """Handle webcam service errors."""
         try:
+            # Ensure camera is fully stopped so buttons reset and user can retry
+            self._stop_camera()
+            self.action_buttons.snapshot_button.setEnabled(False)
+
             self.preview_area.show_error(message)
             self.status_label.setText(f"Error: {message}")
             self.logger.error(f"Webcam error: {message}")
-            
+
         except Exception as e:
             self.logger.error(f"Error handling webcam error: {e}")
     


### PR DESCRIPTION
## Summary
- Reset webcam action buttons when an error occurs by stopping the camera and disabling snapshot

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `PYTHONPATH=MeTuber QT_QPA_PLATFORM=offscreen python test_webcam_error.py` (script inline)

------
https://chatgpt.com/codex/tasks/task_e_68a286dc34b883298bd4346ac47a8ea8