### PR TITLE
Ensure camera start failures reset button states

### DIFF
--- a/MeTuber/src/gui/components/action_buttons.py
+++ b/MeTuber/src/gui/components/action_buttons.py
@@ -54,9 +54,7 @@ class ActionButtons(QWidget):
     def _on_start_clicked(self) -> None:
         """Handle start button click event."""
         try:
-            self.start_button.setEnabled(False)
-            self.stop_button.setEnabled(True)
-            self.snapshot_button.setEnabled(True)
+            # Only emit the signal; the main window will handle state changes
             self.start_camera.emit()
             self.logger.debug("Start camera signal emitted")
         except Exception as e:


### PR DESCRIPTION
## Summary
- Reset action buttons if camera start fails
- Move start-button state logic from ActionButtons to main window

## Testing
- `python -m py_compile MeTuber/src/gui/components/action_buttons.py MeTuber/src/gui/v2_main_window.py`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a286ca3a9c83298e82f1ac739669ad