### PR TITLE
Use style selection to start webcam with proper variant

### DIFF
--- a/MeTuber/src/gui/v2_main_window.py
+++ b/MeTuber/src/gui/v2_main_window.py
@@ -416,10 +416,13 @@ class V2MainWindow(QMainWindow):
                 return
             
             # Get current style and parameters
-            current_style = self.style_selector.get_current_style()
+            selection = self.style_selector.get_current_selection()
+            style_instance = self.style_manager.get_style_with_variant(
+                selection["style"], selection["variant"]
+            )
             current_params = self.parameter_controls.get_parameters()
-            
-            if self.webcam_service.start(device_id, current_style, current_params):
+
+            if self.webcam_service.start(device_id, style_instance, current_params):
                 self.preview_area.set_playing_state(True)
                 self.action_buttons.start_button.setEnabled(False)
                 self.action_buttons.stop_button.setEnabled(True)


### PR DESCRIPTION
## Summary
- use `V2StyleSelector.get_current_selection` to retrieve chosen style/variant
- fetch style instance via `StyleManager.get_style_with_variant`
- pass style instance to `WebcamService.start`

## Testing
- `pytest MeTuber/tests/core/test_device_manager.py::test_device_manager_initialization -q` *(fails: ModuleNotFoundError: No module named 'av')*
- `pip install -r requirements.txt` *(fails: AttributeError: module 'pkgutil' has no attribute 'ImpImporter')*

------
https://chatgpt.com/codex/tasks/task_e_68a286c882dc8329a0fbaf050fc95f80