### PR TITLE
Disable snapshot button when camera stops in V2 UI

### DIFF
--- a/MeTuber/src/gui/v2_main_window.py
+++ b/MeTuber/src/gui/v2_main_window.py
@@ -439,6 +439,7 @@ class V2MainWindow(QMainWindow):
             self.preview_area.set_playing_state(False)
             self.action_buttons.start_button.setEnabled(True)
             self.action_buttons.stop_button.setEnabled(False)
+            self.action_buttons.snapshot_button.setEnabled(False)
             self.status_label.setText("Camera stopped")
             self.accessibility_manager.announce_status("Camera stopped")
             

--- a/MeTuber/tests/gui/test_v2_main_window.py
+++ b/MeTuber/tests/gui/test_v2_main_window.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from PyQt5.QtCore import Qt
+
+from src.gui.v2_main_window import V2MainWindow
+
+
+@pytest.fixture
+def mock_managers():
+    """Create mock manager instances for V2MainWindow."""
+    with patch('src.gui.v2_main_window.SettingsManager') as mock_settings, \
+         patch('src.gui.v2_main_window.DeviceManagerFactory') as mock_device_factory, \
+         patch('src.gui.v2_main_window.StyleManager') as mock_style, \
+         patch('src.gui.v2_main_window.WebcamService') as mock_webcam:
+
+        mock_settings_instance = MagicMock()
+        mock_settings.return_value = mock_settings_instance
+        mock_device = MagicMock()
+        mock_device_factory.create.return_value = mock_device
+        mock_style.return_value = MagicMock()
+        mock_webcam_instance = MagicMock()
+        mock_webcam.return_value = mock_webcam_instance
+
+        yield {
+            'settings': mock_settings_instance,
+            'device': mock_device,
+            'style': mock_style.return_value,
+            'webcam': mock_webcam_instance,
+        }
+
+
+@pytest.fixture
+def v2_main_window(qtbot, mock_managers):
+    """Create a V2MainWindow instance for testing."""
+    window = V2MainWindow()
+    qtbot.addWidget(window)
+    return window
+
+
+def test_stop_camera_via_ui_disables_snapshot(v2_main_window, qtbot):
+    """Stopping the camera via the UI disables the snapshot button."""
+    window = v2_main_window
+    # Simulate running state
+    window.action_buttons.snapshot_button.setEnabled(True)
+    window.action_buttons.stop_button.setEnabled(True)
+
+    qtbot.mouseClick(window.action_buttons.stop_button, Qt.LeftButton)
+
+    assert not window.action_buttons.snapshot_button.isEnabled()
+
+
+def test_stop_camera_programmatically_disables_snapshot(v2_main_window):
+    """Stopping the camera programmatically disables the snapshot button."""
+    window = v2_main_window
+    window.action_buttons.snapshot_button.setEnabled(True)
+    window.action_buttons.stop_button.setEnabled(True)
+
+    window._stop_camera()
+
+    assert not window.action_buttons.snapshot_button.isEnabled()


### PR DESCRIPTION
## Summary
- ensure `_stop_camera` also disables the snapshot button so snapshots are unavailable once the camera stops
- add tests verifying the snapshot button is disabled when stopping via UI or programmatically

## Testing
- `QT_QPA_PLATFORM=offscreen pytest MeTuber/tests/gui/test_v2_main_window.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a286dd9524832980252d907c6c1b12